### PR TITLE
Fix inconsistency in program's arguments and details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## eth-utils
 
-ethereum utilities, dev tools, scripts, etc
+Ethereum utilities, dev tools, scripts, etc.
 
 * `gethup.sh`: primitive wrapper to [geth](https://github.com/ethereum/go-ethereum)
 * `gethcluster.sh`: launch local clusters non-interactively (https://github.com/ethereum/go-ethereum/wiki/Setting-up-private-network-or-local-cluster)
@@ -11,7 +11,7 @@ ethereum utilities, dev tools, scripts, etc
 ### Launch an instance 
 
 ```
-GETH=./geth bash /path/to/eth-utils/gethup.sh <rootdir> <dd> <run> <params>...
+GETH=geth bash /path/to/eth-utils/gethup.sh <rootdir> <dd> <run> <params>
 ```
 
 This will
@@ -24,7 +24,7 @@ This will
 - extra params are passed to `geth` 
 
 ```
-$ GETH=./geth bash ~/eth-utils/gethup.sh ~/tmp/eth/ 04 09 --mine console 
+$ GETH=geth bash ~/eth-utils/gethup.sh ~/tmp/eth/ 04 09 --mine console 
 Welcome to the FRONTIER
 > eth.getBalance(eth.coinbase)
 '198400000000001'
@@ -35,7 +35,7 @@ Welcome to the FRONTIER
 Running a cluster of 8 instances under dir `tmp/eth/` isolated on local eth network (id 3301), launch 05. Give external IP and pass extra param `--mine`.
 
 ```
-GETH=./geth bash gethcluster.sh <root> <n> <network_id> <runid> <IP> [[params]...]
+GETH=geth bash /path/to/eth-utils/gethcluster.sh <root> <n> <network_id> <runid> <IP> <params>
 ```
 
 This will set up a local cluster of nodes
@@ -98,7 +98,7 @@ cd eth-netstats
 npm install
 ```
 
-####Configuring netstat for your cluster
+#### Configuring netstat for your cluster
 
 ```
 bash /path/to/eth-utils/netstatconf.sh <number_of_clusters> <name_prefix> <ws_server> <ws_secret> 
@@ -118,7 +118,7 @@ cd eth-utils
 bash ./netstatconfig.sh 8 cicada http://localhost:3301 kscc > ~/leagues/3301/cicada.json
 ```
 
-####Installing eth-net-intelligence-api
+#### Installing eth-net-intelligence-api
 
 ```
 git clone https://github.com/cubedro/eth-net-intelligence-api
@@ -146,7 +146,7 @@ pm2 start ~/leagues/3301/cicada.json
 ```
 
 
-####Starting the monitor 
+#### Starting the monitor 
 
 Use your own eth-netstat server to monitor a league on a port corresponding to a league
 

--- a/gethup.sh
+++ b/gethup.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
-# Usage:
-# bash /path/to/eth-utils/gethup.sh <datadir> <instance_name>
+# Usage: GETH=geth bash /path/to/eth-utils/gethup.sh <rootdir> <instance_name> <run> <params>
+
 
 root=$1  # base directory to use for datadir and logs
 shift
 dd=$1  # double digit instance id like 00 01 02
 shift
-
 
 # logs are output to a date-tagged file for each run , while a link is
 # created to the latest, so that monitoring be easier with the same filename
@@ -14,7 +13,7 @@ shift
 # GETH=geth
 
 # geth CLI params       e.g., (dd=04, run=09)
-datetag=`date "+%c%y%m%d-%H%M%S"|cut -d ' ' -f 5`
+datetag=`date "+%c%y%m%d-%H%M%S" | cut -d ' ' -f 5`
 datadir=$root/data/$dd        # /tmp/eth/04
 log=$root/log/$dd.$datetag.log     # /tmp/eth/04.09.log
 linklog=$root/log/$dd.current.log     # /tmp/eth/04.09.log
@@ -51,7 +50,7 @@ echo "copying keys $root/keystore/$dd $datadir/keystore"
 cp -R $root/keystore/$dd/keystore/ $datadir/keystore/
 # fi
 
-BZZKEY=`$GETH --datadir=$datadir account list|head -n1|perl -ne '/([a-f0-9]{40})/ && print $1'`
+BZZKEY=`$GETH --datadir=$datadir account list | head -n1 | perl -ne '/([a-f0-9]{40})/ && print $1'`
 
 # bring up node `dd` (double digit)
 # - using <rootdir>/<dd>


### PR DESCRIPTION
- There were multiple definitions of gethcluster's arguments.
- GETH=geth instead of GETH=./geth
- Details like typos in README.