### PR TITLE
Updated the command for running local cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Welcome to the FRONTIER
 Running a cluster of 8 instances under dir `tmp/eth/` isolated on local eth network (id 3301), launch 05. Give external IP and pass extra param `--mine`.
 
 ```
-GETH=./geth bash gethcluster.sh <root> <n> <network_id> <runid> <IP> [[params]...]
+GETH=./geth bash gethcluster.sh <root> <network_id> <number_of_nodes>  <runid> <local_IP> [[params]...]
 ```
 
 This will set up a local cluster of nodes


### PR DESCRIPTION
Order of parameters was slightly wrong
as a result network id and number of nodes was flipped.
Leading to creation of 3301 nodes (instead of a smaller number)